### PR TITLE
Train rgb for 50 epochs and then train dhs for another 50 epochs

### DIFF
--- a/configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_coco_RGB_load_from.py
+++ b/configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_coco_RGB_load_from.py
@@ -89,4 +89,4 @@ optimizer = dict(
             'norm': dict(decay_mult=0.)
         }))
 lr_config = dict(warmup_iters=1000, step=[27, 33])
-runner = dict(max_epochs=100)
+runner = dict(max_epochs=50)

--- a/configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_sunrgbd_rgb2dhs.py
+++ b/configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_sunrgbd_rgb2dhs.py
@@ -7,7 +7,7 @@ _base_ = [
 #pretrained = 'https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_tiny_patch4_window7_224.pth'  # noqa
 # Seems that the pretrained performs poorly, let's use load from insted
 #load_from= 'checkpoints/mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco_20210908_165006-90a4008c.pth'
-load_from='/data/sophia/a/Xiaoke.Shen54/repos/SwinTransFusion/work_dirs/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_coco_RGB_load_from/epoch_100.pth'
+load_from='/data/sophia/a/Xiaoke.Shen54/repos/SwinTransFusion/work_dirs/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_coco_RGB_load_from/epoch_50.pth'
 model = dict(
     type='MaskRCNN',
     backbone=dict(
@@ -90,4 +90,4 @@ optimizer = dict(
             'norm': dict(decay_mult=0.)
         }))
 lr_config = dict(warmup_iters=1000, step=[27, 33])
-runner = dict(max_epochs=100)
+runner = dict(max_epochs=50)

--- a/sunrgbd/shell_script/yonod/train_swin_transform.sh
+++ b/sunrgbd/shell_script/yonod/train_swin_transform.sh
@@ -1,8 +1,18 @@
-
-# train RGB with  pretrained weights from coco
+<<comment
+# train RGB with  pretrained weights from coco for 100 epochs
 #cfg=configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_coco_RGB_load_from.py 
 #python tools/train.py  ${cfg} > train_swin_for_sunrgbd_data_by_rgb_images_with_pretrain_weight_from_coco.log
 
-# Train DHS with pretrained weights from RGB of sunrgbd dataset
+# Train DHS with pretrained weights from RGB of sunrgbd dataset based on the previous RGB 100 epoch checkpoint and train another 50 epochs
 cfg=configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_sunrgbd_rgb2dhs.py 
 python tools/train.py  ${cfg} > train_swin_rgb2dhs.log 
+comment
+# train RGB with  pretrained weights from coco for 50 epoch only
+cfg=configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_coco_RGB_load_from.py 
+echo "train rgb"
+python tools/train.py  ${cfg} > train_swin_for_sunrgbd_data_by_rgb_images_with_pretrain_weight_from_coco_50epochs.log
+
+# Train DHS with pretrained weights from RGB of sunrgbd dataset based on the previous RGB 50 epoch and train another 50 epochs
+cfg=configs/swin/mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_sunrgbd_rgb2dhs.py 
+echo "train dhs"
+python tools/train.py  ${cfg} > train_swin_rgb2dhs_50epochs.log 


### PR DESCRIPTION
Related to [issue](https://github.com/liketheflower/YONOD/issues/4)
The RGBtoDHS experiment is redone to collect all the checkpoints. Right now, we have:
- The first 50 epoch is train and test based on RGB images
- The second 50 epoch is train and test based on the DHS images from the epoch 50 checkpoint.

When collecting all the checkpoints, we will test:
- DHS image's performance on the first 50 epochs
- RGB images's performance on the second 50 epochs.